### PR TITLE
Update the flipper to use Bounds instead of frame

### DIFF
--- a/DJKFlipper/DJKFlipperView.swift
+++ b/DJKFlipper/DJKFlipperView.swift
@@ -27,7 +27,7 @@ open class DJKFlipperView: UIView {
     open var dataSource:DJKFlipperDataSource?
     
     lazy var staticView:DJKStaticView = {
-        let view = DJKStaticView(frame: self.frame)
+        let view = DJKStaticView(frame: self.bounds)
         return view
         }()
     
@@ -63,7 +63,7 @@ open class DJKFlipperView: UIView {
     
     override open func layoutSubviews() {
         super.layoutSubviews()
-        self.staticView.updateFrame(self.frame)
+        self.staticView.updateFrame(self.bounds)
     }
     
     func updateTheActiveView() {

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ func viewForPage(page:NSInteger, flipper:DJKFlipperView) -> UIView
  - Everytime a page will flip you will need to pass the view of the viewcontroller you want to display.
 ```swift
 func viewForPage(page: NSInteger, flipper: DJKFlipperView) -> UIView {
+    yourViewControllerArray[page].view.bounds = flipView.bounds
     return yourViewControllerArray[page].view
 }
 ```


### PR DESCRIPTION
when the flipper view is used in an inner view -Not full screen- the animation gets missed up as the static view changes location during animation